### PR TITLE
UI improvements to "Regions" page

### DIFF
--- a/03-apps/wbi/R/mod_regions.R
+++ b/03-apps/wbi/R/mod_regions.R
@@ -178,6 +178,7 @@ mod_regions_server <- function(id){
           resizable = TRUE, 
           bordered = TRUE, 
           defaultColDef = reactable::colDef(minWidth = 75), 
+          defaultPageSize = 50,
           # Specify individual column settings
           columns = list(
             Index = reactable::colDef(show = FALSE), 

--- a/03-apps/wbi/R/mod_regions.R
+++ b/03-apps/wbi/R/mod_regions.R
@@ -17,37 +17,43 @@ mod_regions_ui <- function(id){
       fluidRow(
         
         column(
-          width = 3, 
-          align = "center", 
+          width = 6, 
           
-          radioButtons(
-            inputId = ns("regions_element_type"), 
-            label = "Species Group:", 
-            choices = c("Birds" = "bird", "Productivity" = "prod", "Trees" = "tree"), 
-            selected = "bird", 
-            inline = FALSE
-          )
-          
-        ), 
-        
-        column(
-          width = 4, 
-          
-          selectInput(
+          shinyWidgets::pickerInput(
             inputId = ns("regions_element"),
             label = "Species Name:", 
-            choices = ELEMENT_NAMES$bird
+            choices = ELEMENT_NAMES, 
+            options = list(
+              `live-search` = TRUE
+              # style = "border-color: #999999;"
+              # style = paste0(
+              #   "background-color: white; ",
+              #   "border-color: #999999; ",
+              #   "font-family: 'Helvetica Neue' Helvetica; ",
+              #   "font-weight: 200;"
+              # )
+            )
           )
           
         ), 
         
         column(
-          width = 5, 
+          width = 6, 
           
-          selectInput(
+          shinyWidgets::pickerInput(
             inputId = ns("regions_region"),
-            label = "Region:",
-            choices = row.names(STATS$regions)
+            label = "Region:", 
+            choices = split(STATS$regions$region, STATS$regions$classification), 
+            options = list(
+              `live-search` = TRUE
+              # style = "border-color: #999999;"
+              # style = paste0(
+              #   "background-color: white; ",
+              #   "border-color: #999999; ",
+              #   "font-family: 'Helvetica Neue' Helvetica; ",
+              #   "font-weight: 200;"
+              # )
+            )
           )
           
         )


### PR DESCRIPTION
This PR accomplishes closes #34 by:

1. Nesting drop-down filters for "Species Name" and "Region", and removing the radio button
2. Making 50 the maximum number of rows shown in the {reactable} table's scrollable area before pagination kicks in

Note that for the second item listed above, if we set the maximum number of rows shown in the table to 50, the table will *never* have pagination (given the current data).  For example, the elements with the greatest period frequency contain an observation every 10 years from 2011 - 2100.  Across 4 scenarios, this amounts to `10 * 4 = 40` rows of data.